### PR TITLE
Change refresh timer default to just over 4 hours.  Add support for StatusActive and StatusFault.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ YoLink status is retrieved over the internet.  While the plugin maintains a stat
             "mqttPort": 8003,
             "userAccessId": "ua_0123456789abcdef",
             "secretKey": "sec_v1_0123456789abcdef==",
-            "refreshAfter": 3600,
+            "refreshAfter": 14500,
             "verboseLog": false,
             "liteLog": true,
             "allDevices": true,
@@ -68,7 +68,7 @@ YoLink status is retrieved over the internet.  While the plugin maintains a stat
                         "hide": true,
                         "name": "YoLink Hub",
                         "model": "YS1603-UC",
-                        "refreshAfter": 1800
+                        "refreshAfter": 14500
                     }
                 }
             ]
@@ -85,7 +85,7 @@ YoLink status is retrieved over the internet.  While the plugin maintains a stat
   * **userAccessId** *(required)*: Obtain from the YoLink app on your mobile device...  
   Settings->Account->Advanced Settings->User Access Credentials.  If none exist use the (+) button to request credentials be generated for you.  Copy down the UAID (user access ID) and Secret Key.
   * **secretKey** *(required)*: Secret key obtained as descrived above.
-  * **refreshAfter** *(optional)*: The plugin maintains a cache of device status so that it can response very quickly to state requests from HomeKit without having to send a request to the YoLink servers.  This is specified in number of seconds and defaults to 3600 (one hour) which means that if the plugin cache is not updated in the last hour then retrieve status from the YoLink server.  If set to zero than the plugin will always request status from YoLink servers for every HomeKit request (not recommended).
+  * **refreshAfter** *(optional)*: The plugin maintains a cache of device status so that it can response very quickly to state requests from HomeKit without having to send a request to the YoLink servers.  This is specified in number of seconds and defaults to 14500 (just over 4 hours) which means that if the plugin cache is not updated during this period then retrieve status from the YoLink server.  If set to zero than the plugin will always request status from YoLink servers for every HomeKit request (not recommended).
   * **verboseLog** *(optional)*: Sometimes it is helpful to log more detail than *info* but somewhat less than *debug*. This is that half-way.  Defaults to false.
   * **liteLog** *(optional)*: HomeKit makes frequent requests for device status, this suppresses logging of every request (unless verboseLog is true).  Requests that require message be sent to YoLink servers are still logged.  Defaults to true.
   * **allDevices** *(optional)*: If set to false then only devices listed in the Devices section of the config file are loaded, and then only if the hide property is false. Defaults to true so all devices reported by YoLink are loaded (if hide property is false).
@@ -101,11 +101,11 @@ YoLink status is retrieved over the internet.  While the plugin maintains a stat
 
 ## MQTT
 
-The plugin registers with YoLink servers as a MQTT client and subscribes to published reports to receive alerts (e.g. motion sensor detects movement) which are forwarded to homebridge. At the time of writing the resiliency of the MQTT client has not been fully tested, so how well it responds to roaming (change of IP address) or disconnects is not fully known.  Logging is enabled to trace events, please report if the MQTT client stops working.
+The plugin registers with YoLink servers as a MQTT client and subscribes to published messages to receive alerts (e.g. motion sensor detects movement) which are forwarded to homebridge. At the time of writing the resiliency of the MQTT client has not been fully tested, so how well it responds to roaming (change of IP address) or disconnects is not fully known.  Logging is enabled to trace events, please report if the MQTT client stops working.
 
-MQTT client is receives updates from YoLink devices at different times depending on the device.  An alert event generates a message immediately but regular updates are received when there is no alert. Devices like the leak detector every 4 hours, but tempearture and humidity sensor sends updates based on environmental change rate, or at least every hour.  This is documented in YoLink user guide.
+MQTT client is receives updates from YoLink devices at different times depending on the device.  An alert event generates a message immediately but regular updates are received when there is no alert. Devices like the leak detector report every 4 hours, but tempearture and humidity sensor sends updates based on environmental change rate, or at least every hour.  This is documented in YoLink user guide.
 
-If you are comfortable relying entirely on these notifications you can set the *refreshAfter* property to something larger than 14400 seconds (4 hours) which will cause the plugin to always report the cached state of a device, unless the MQTT client has not received and update in the prior 4 hours.
+If you are comfortable relying entirely on YoLink notifications you can set the *refreshAfter* property to something larger than 14400 seconds (4 hours) which will cause the plugin to always report the cached state of a device, updating the cache whenever YoLink sends a report or when an internal timer runs based on *refreshAfter*.  If this is set to less than 60 seconds then timers will not run, but data will be refreshed on HomeKit requests more than 60 seconds from the previous request.
 
 ## License
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -58,7 +58,7 @@
         "title": "Refresh time for data from YoLink server",
         "type": "number",
         "required": false,
-        "default": 3600,
+        "default": 14500,
         "minimum": 0,
         "maximum":86400,
         "description": "When HomeKit requests status, request from YoLink server if our cache has not been updated within the time specified. Zero (not recommended) means always retrieve from the server, maximum value is 86400 (24 hours).  Note that, at the time of writing, MQTT provides updates for each device every 4 hours."
@@ -94,7 +94,7 @@
               "title": "Device Identifier",
               "type": "string",
               "required": true,
-              "default": "0123456789abcdef",
+              "default": "",
               "description":"You can find the Device ID in the Homebridge log or in the Homebridge Config UI by clicking on an accessory's settings and copying the Serial Number field."
             },
             "config": {
@@ -125,7 +125,7 @@
                   "title": "Refresh time for data from YoLink server (override global setting)",
                   "type": "number",
                   "required": false,
-                  "default": 3600,
+                  "default": 14500,
                   "minimum": 0,
                   "maximum":86400
                 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge YoLink",
   "name": "homebridge-yolink",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Connect to YoLink.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/leakDevice.ts
+++ b/src/leakDevice.ts
@@ -54,14 +54,22 @@ async function handleGet(this: YoLinkPlatformAccessory): Promise<CharacteristicV
   const device = this.accessory.context.device;
   let rc = platform.api.hap.Characteristic.LeakDetected.LEAK_NOT_DETECTED;
 
-  if (await this.checkDeviceState(platform, device)) {
-    this.leakService.updateCharacteristic(platform.Characteristic.StatusLowBattery, (device.data.state.battery <= 1)
-      ? platform.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
-      : platform.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
+  if (await this.checkDeviceState(platform, device) && device.data.online) {
+    this.leakService
+      .updateCharacteristic(platform.Characteristic.StatusLowBattery, (device.data.state.battery <= 1)
+        ? platform.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW
+        : platform.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL)
+      .updateCharacteristic(platform.Characteristic.StatusActive, true)
+      .updateCharacteristic(platform.Characteristic.StatusFault, false);
     platform.liteLog('Device state for ' + device.name + ' (' + device.deviceId + ') is: ' + device.data.state.state);
     if (device.data.state.state === 'alert') {
       rc = platform.api.hap.Characteristic.LeakDetected.LEAK_DETECTED;
     }
+  } else {
+    platform.log.error('Device offline or other error for '+ device.name + ' (' + device.deviceId + ')');
+    this.leakService
+      .updateCharacteristic(platform.Characteristic.StatusActive, false)
+      .updateCharacteristic(platform.Characteristic.StatusFault, true);
   }
 
   await releaseSemaphore();
@@ -120,7 +128,9 @@ export async function mqttLeakSensor(deviceClass: YoLinkPlatformAccessory, messa
         .updateCharacteristic(platform.Characteristic.LeakDetected,
           (message.data.state === 'alert')
             ? platform.api.hap.Characteristic.LeakDetected.LEAK_DETECTED
-            : platform.api.hap.Characteristic.LeakDetected.LEAK_NOT_DETECTED);
+            : platform.api.hap.Characteristic.LeakDetected.LEAK_NOT_DETECTED)
+        .updateCharacteristic(platform.Characteristic.StatusActive, true)
+        .updateCharacteristic(platform.Characteristic.StatusFault, false);
       break;
     default:
       platform.log.warn('Unsupported mqtt event: \'' + message.event + '\'\n'

--- a/src/leakDevice.ts
+++ b/src/leakDevice.ts
@@ -22,8 +22,9 @@ export async function initLeakSensor(deviceClass: YoLinkPlatformAccessory): Prom
   deviceClass.leakService.setCharacteristic(platform.Characteristic.Name, device.name);
   deviceClass.leakService.getCharacteristic(platform.Characteristic.LeakDetected)
     .onGet(handleGet.bind(deviceClass));
-  // Call get handler to initialize data fields to current state
-  handleGet.bind(deviceClass)();
+  // Call get handler to initialize data fields to current state and set
+  // timer to regularly update the data.
+  deviceClass.refreshDataTimer(handleGet.bind(deviceClass));
 }
 
 /***********************************************************************

--- a/src/motionDevice.ts
+++ b/src/motionDevice.ts
@@ -22,8 +22,9 @@ export async function initMotionSensor(deviceClass: YoLinkPlatformAccessory): Pr
   deviceClass.motionService.setCharacteristic(platform.Characteristic.Name, device.name);
   deviceClass.motionService.getCharacteristic(platform.Characteristic.MotionDetected)
     .onGet(handleGet.bind(deviceClass));
-  // Call get handler to initialize data fields to current state
-  handleGet.bind(deviceClass)();
+  // Call get handler to initialize data fields to current state and set
+  // timer to regularly update the data.
+  deviceClass.refreshDataTimer(handleGet.bind(deviceClass));
 }
 
 /***********************************************************************

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,4 +15,4 @@ export const YOLINK_MQTT_PORT = 8003;
 export const YOLINK_API_URL = 'https://api.yosmart.com/open/yolink/v2/api';
 export const YOLINK_TOKEN_URL = 'https://api.yosmart.com/open/yolink/token';
 
-export const YOLINK_REFRESH_INTERVAL = 3600;
+export const YOLINK_REFRESH_INTERVAL = 14500;

--- a/src/thermoHydroDevice.ts
+++ b/src/thermoHydroDevice.ts
@@ -29,9 +29,9 @@ export async function initThermoHydroDevice(deviceClass: YoLinkPlatformAccessory
   deviceClass.hydroService.setCharacteristic(platform.Characteristic.Name, device.name);
   deviceClass.hydroService.getCharacteristic(platform.Characteristic.CurrentRelativeHumidity)
     .onGet(handleHydroGet.bind(deviceClass));
-  // Call get handler to initialize data fields to current state
-  handleThermoGet.bind(deviceClass)();
-  handleHydroGet.bind(deviceClass)();
+  // Call get handler to initialize data fields to current state and set
+  // timer to regularly update the data.
+  deviceClass.refreshDataTimer(handleThermoGet.bind(deviceClass));
 }
 
 /***********************************************************************

--- a/src/valveDevice.ts
+++ b/src/valveDevice.ts
@@ -27,8 +27,9 @@ export async function initValveDevice(deviceClass: YoLinkPlatformAccessory): Pro
     .onGet(handleInUse.bind(deviceClass));
   deviceClass.valveService.getCharacteristic(platform.Characteristic.ValveType)
     .onGet(handleType.bind(deviceClass));
-  // Call get handler to initialize data fields to current state
-  handleGet.bind(deviceClass)();
+  // Call get handler to initialize data fields to current state and set
+  // timer to regularly update the data.
+  deviceClass.refreshDataTimer(handleGet.bind(deviceClass));
 }
 
 /***********************************************************************

--- a/src/yolinkAPI.ts
+++ b/src/yolinkAPI.ts
@@ -123,7 +123,7 @@ export class YoLinkAPI {
     this.yolinkLoggedIn = true;
 
     platform.log.info('Access Token expires in ' + this.yolinkTokens.expires_in + ' seconds. We will refresh on requests after '
-    + Math.floor(this.yolinkTokens.expires_in * this.accessTokenRefreshAt) + ' seconds');
+                                                 + Math.floor(this.yolinkTokens.expires_in * this.accessTokenRefreshAt) + ' seconds');
 
     if (this.accessTokenHeartbeat) {
       // If interval timer already running, kill it so we can start a new one.
@@ -132,7 +132,7 @@ export class YoLinkAPI {
     platform.log.info('Starting heartbeat to force access token refresh every '
       + (this.yolinkTokens.expires_in * this.accesstokenHeartbeatAt) + ' seconds');
     this.accessTokenHeartbeat = setInterval( () => {
-      platform.log.info('Refresh access token timer fired');
+      platform.liteLog('Refresh access token timer fired');
       this.getAccessToken(platform);
     }, this.yolinkTokens.expires_in * 1000 * this.accesstokenHeartbeatAt );
 


### PR DESCRIPTION
YoLink devices send updated over MQTT and for some devices this is as infrequent as every 4 hours.  More active devices like temperature sensors send updates more frequently.  I am changing the default *refreshAfter* config setting to just over 4 hours so that we don't, by default, ask for data more frequently than YoLink would.  The presumption is that this is tuned by YoLink to be most efficient on e.g. battery life.

Also added support for StatusActive and StatusFault so that if we detect something gone wrong with a device then we report it to HomeKit and log in Homebridge logs as an error.