### PR TITLE
Remove experimental from Switch and Siren. Reduce intensity of loggin…

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Currently supports the following devices:
 * Weatherproof Temperature and Humidity Sensor
 * Door Sensor (as a contact sensor)
 * Key fob remote (as stateless programmable switch)
-* Siren / Switch (experimental)
+* Siren (as a switch)
+* Switch
 * Outlet (single)
 
 The plugin registers as a MQTT client and subscribes to reports published by YoLink for real time alerts and status updates.
@@ -44,7 +45,7 @@ Search for "yolink" in [homebridge-config-ui-x](https://github.com/oznu/homebrid
 sudo npm install -g homebridge-yolink
 ```
 
-YoLink status is retrieved over the internet. While the plugin maintains a status cache, you may consider use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges).
+YoLink status is retrieved over the internet. While the plugin maintains a status cache, **use of Homebridge [child bridge](https://github.com/homebridge/homebridge/wiki/Child-Bridges)** is strongly encouraged.  As noted below in the *network resiliency* section, this plugin will make multiple attempts to fulfill a request if necessary, which can take time.
 
 ## Configuration
 
@@ -169,11 +170,11 @@ Simultaneously pressing more than one button will generate a long press signal f
 
 Some latency has been observed between pressing a button and it being reported by YoLink. Additional latency is incurred by waiting for a double-press event. If you never use double-press then a small reduction in latency can be achieved by setting the *doublePress* setting to zero.
 
-### Siren (experimental)
+### Siren
 
 A YoLink siren has been implemented as a switch which can be turned on or off in Homebridge/HomeKit.
 
-### Switch (experimental)
+### Switch
 
 A Switch device is implemented to support adding YoLink siren. This is untested, if you have a YoLink switch please report back.
 
@@ -195,7 +196,7 @@ Various strategies are employed in an attempt to handle an unstable network. If 
 
 For login and retrieving access tokens the plugin will retry indefinitely with 5 second initial delay, increasing by 5 seconds for each repeated attempt to a maximum of 60 seconds between retries. If the network goes down, then this should ensure that the connection to YoLink is reestablished within 60 seconds of network recoverd.
 
-For getting or setting device information the plugin will retry a maximum of 5 times before giving up. The initial retry delay is 2 seconds, incrementing by 2 seconds each time with a maximum interval of 10 seconds.
+For getting or setting device information the plugin will retry a maximum of 10 times before giving up. The initial retry delay is 2 seconds, incrementing by 2 seconds each time with a maximum interval of 10 seconds.  After all attempts it will fail with a message to log, but this will not terminate the plugin.
 
 The MQTT callback will attempt to reconnect, if necessary with login / access token retrieval that follow the above procedure.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge YoLink",
   "name": "homebridge-yolink",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Connect to YoLink.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/deviceHandlers.ts
+++ b/src/deviceHandlers.ts
@@ -25,8 +25,8 @@ export const deviceFeatures = {
   Manipulator: { experimental: false, hasBattery: true },
   THSensor: { experimental: false, hasBattery: true },
   DoorSensor: { experimental: false, hasBattery: true },
-  Siren: { experimental: true, hasBattery: true },
-  Switch: { experimental: true, hasBattery: false },
+  Siren: { experimental: false, hasBattery: true },
+  Switch: { experimental: false, hasBattery: false },
   Outlet: { experimental: false, hasBattery: false },
   SmartRemoter: { experimental: false, hasBattery: true },
 };

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -128,7 +128,7 @@ export class YoLinkPlatformAccessory {
       }
     } catch(e) {
       const msg = (e instanceof Error) ? e.stack : e;
-      platform.log.error('Error in checkDeviceState' + platform.reportError + msg);
+      platform.log.info('Error in checkDeviceState' + platform.reportError + msg);
     }
     return(device.data);
   }

--- a/src/unknownDevice.ts
+++ b/src/unknownDevice.ts
@@ -23,9 +23,6 @@ export async function initUnknownDevice(this: YoLinkPlatformAccessory): Promise<
   platform.log.warn(`YoLink device type: '${device.type}' is not supported (${this.deviceMsgName}) (initialize)`
     + platform.reportError + JSON.stringify(device));
 
-  // As this is an unknown device, don't attempt to get data any more
-  // frequently than once an hour.
-  this.config.refreshAfter = Math.max(3600, this.config.refreshAfter);
   this.refreshDataTimer(handleGet.bind(this));
 }
 

--- a/src/yolinkAPI.ts
+++ b/src/yolinkAPI.ts
@@ -69,7 +69,7 @@ function retryFn(platform, fn, retriesLeft = 5, interval = 2000, intervalInc = 2
           return;
         }
         const msg = (e instanceof Error) ? e.message : e;
-        platform.log.warn(`Retry ${fn.name} due to error, try again in ${Math.floor(interval/1000)} second(s): ${msg}`);
+        platform.liteLog(`Retry ${fn.name} due to error, try again in ${Math.floor(interval/1000)} second(s): ${msg}`);
         setTimeout(() => {
           retryFn(platform, fn, (retriesLeft) ? retriesLeft - 1 : 0, Math.min(interval+intervalInc, intervalMax), intervalInc, intervalMax)
             .then(resolve, reject);
@@ -299,9 +299,9 @@ export class YoLinkAPI {
    *
    */
   async getDeviceState(platform: YoLinkHomebridgePlatform, device): Promise<yolinkBUDP> {
-    // Retry 5 times. On failure retry after 1 seconds.  Add 1 seconds for
-    // each failure with maximum of 5 seconds between each retry.
-    return await retryFn(platform, this.tryGetDeviceState.bind(this, platform, device), 5, 1000, 1000, 5000) as yolinkBUDP;
+    // Retry 10 times. On failure retry after 2 seconds.  Add 2 seconds for
+    // each failure with maximum of 10 seconds between each retry.
+    return await retryFn(platform, this.tryGetDeviceState.bind(this, platform, device), 10, 2000, 2000, 10000) as yolinkBUDP;
   }
 
   async tryGetDeviceState(platform: YoLinkHomebridgePlatform, device) {
@@ -333,9 +333,9 @@ export class YoLinkAPI {
    *
    */
   async setDeviceState(platform: YoLinkHomebridgePlatform, device, state): Promise<yolinkBUDP> {
-    // Retry 5 times. On failure retry after 1 seconds.  Add 1 seconds for
+    // Retry 10 times. On failure retry after 2 seconds.  Add 2 seconds for
     // each failure with maximum of 5 seconds between each retry.
-    return await retryFn(platform, this.trySetDeviceState.bind(this, platform, device, state), 5, 1000, 1000, 5000) as yolinkBUDP;
+    return await retryFn(platform, this.trySetDeviceState.bind(this, platform, device, state), 10, 2000, 2000, 10000) as yolinkBUDP;
   }
 
   async trySetDeviceState(platform: YoLinkHomebridgePlatform, device, state) {


### PR DESCRIPTION
Remove experimental from Switch and Siren. Reduce intensity of logging when need to retry retrieving status from device. And increase number of retries on get/set device state from 5 to 10.