### PR TITLE
Major updates with support for garage door device.

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -60,7 +60,7 @@
         "required": false,
         "default": 14500,
         "minimum": 0,
-        "maximum":86400,
+        "maximum": 86400,
         "description": "Maximum number of seconds for cache data, after which we request an update from YoLink server. Defaults to just over 4 hours. For example, if you want to update at least once an hour, then set this to 3600. Zero (not recommended) means always retrieve from the server, maximum value is 86400 (24 hours)."
       },
       "verboseLog": {
@@ -96,7 +96,7 @@
         "required": false,
         "default": 800,
         "minimum": 0,
-        "maximum":5000,
+        "maximum": 5000,
         "description": "Time in milliseconds between button presses to consider as a double-press. Defaults to 800ms, zero disables double-press events, maximum accepted in user interface is 5000ms (5 seconds)."
       },
       "devices": {
@@ -147,22 +147,50 @@
                   "title": "Refresh time for data from YoLink server (override global setting)",
                   "type": "number",
                   "required": false,
-                  "default": 14500,
                   "minimum": 0,
-                  "maximum":86400
+                  "maximum": 86400
                 },
                 "doublePress": {
                   "title": "Time in milliseconds between button presses to consider as a double-press",
                   "type": "number",
                   "required": false,
-                  "default": 800,
                   "minimum": 0,
-                  "maximum":5000
+                  "maximum": 5000
+                },
+                "nOutlets": {
+                  "title": "Number of outlets in a multi-outlet power strip (multiple USB ports count as one outlet). Must be between 1 and 8, defaults to 5 (YoLink smart power strip)",
+                  "type": "number",
+                  "required": false,
+                  "minimum": 1,
+                  "maximum": 8
                 }
               }   
             }
           }
         }
+      },
+      "garageDoors": {
+        "type": "array",
+        "required": false,
+        "items": {
+          "title": "Garage Doorss",
+          "type": "object",
+          "properties": {
+            "controller": {
+              "title": "Garage Door or Finger controller device",
+              "type": "string",
+              "required": true,
+              "default": ""
+            },
+            "sensor": {
+              "title": "Door Sensor device",
+              "type": "string",
+              "required": true,
+              "default": ""
+            }
+          }
+        },
+        "description":"Pair two devices together into a single Garage Door accessory. You can find the Device ID in the Homebridge log, in the YoLink mobile app (as Device EUI) or in the Homebridge Config UI by clicking on an accessory's settings and copying the Serial Number field."
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge YoLink",
   "name": "homebridge-yolink",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Connect to YoLink.",
   "license": "Apache-2.0",
   "repository": {

--- a/src/deviceHandlers.ts
+++ b/src/deviceHandlers.ts
@@ -15,6 +15,7 @@ import { initContactSensor, mqttContactSensor } from './contactDevice';
 import { initSwitchDevice, mqttSwitchDevice } from './switchDevice';
 import { initOutletDevice, mqttOutletDevice } from './outletDevice';
 import { initStatelessSwitch, mqttStatelessSwitch } from './statelessSwitch';
+import { initGarageDoor, mqttGarageDoor } from './garageDoor';
 
 export const deviceFeatures = {
   Hub: { experimental: false, hasBattery: false },
@@ -29,9 +30,10 @@ export const deviceFeatures = {
   Switch: { experimental: false, hasBattery: false },
   Outlet: { experimental: false, hasBattery: false },
   SmartRemoter: { experimental: false, hasBattery: true },
-  MultiOutlet: { experimental: true, hasBattery: false },
-  GarageDoor: { experimental: true, hasBattery: false },
-  Finger: { experimental: true, hasBattery: true },
+  MultiOutlet: { experimental: false, hasBattery: false },
+  GarageDoor: { experimental: false, hasBattery: false },
+  Finger: { experimental: false, hasBattery: true },
+  GarageDoorCombo: { experimental: false, hasBattery: false },
 };
 
 export const initDeviceService = {
@@ -50,6 +52,7 @@ export const initDeviceService = {
   MultiOutlet(this: YoLinkPlatformAccessory) { initOutletDevice.bind(this)('open', 'open', 'close'); },
   GarageDoor(this: YoLinkPlatformAccessory) { initSwitchDevice.bind(this)('toggle', '', ''); },
   Finger(this: YoLinkPlatformAccessory) { initSwitchDevice.bind(this)('toggle', '', ''); },
+  GarageDoorCombo(this: YoLinkPlatformAccessory) { initGarageDoor.bind(this)(); },
 };
 
 export const mqttHandler = {
@@ -68,4 +71,5 @@ export const mqttHandler = {
   MultiOutlet(this: YoLinkPlatformAccessory, data) { mqttOutletDevice.bind(this)(data); },
   GarageDoor(this: YoLinkPlatformAccessory, data) { mqttSwitchDevice.bind(this)(data); },
   Finger(this: YoLinkPlatformAccessory, data) { mqttSwitchDevice.bind(this)(data); },
+  GarageDoorCombo(this: YoLinkPlatformAccessory, data) { mqttGarageDoor.bind(this)(data); },
 };

--- a/src/garageDoor.ts
+++ b/src/garageDoor.ts
@@ -1,0 +1,276 @@
+/***********************************************************************
+ * YoLink Garage Door device support
+ *
+ * Copyright (c) 2022 David Kerr
+ *
+ */
+
+import { PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { YoLinkHomebridgePlatform } from './platform';
+import Semaphore from 'semaphore-promise';
+import { YoLinkPlatformAccessory } from './platformAccessory';
+import { deviceFeatures} from './deviceHandlers';
+
+/***********************************************************************
+ * initGarageDoor
+ *
+ */
+export async function initGarageDoor(this: YoLinkPlatformAccessory): Promise<void> {
+  const platform: YoLinkHomebridgePlatform = this.platform;
+  const accessory: PlatformAccessory = this.accessory;
+  const controller = this.accessory.context.device;
+  const sensor = this.accessory.context.device2;
+
+  // Need to do some initialization of the second device attached to the
+  // accessory.  The first device is handled in the main platformAccessory class.
+  this.deviceId2 = sensor.deviceId;
+  sensor.deviceMsgName = `${sensor.name} (${sensor.deviceId})`;
+  sensor.config = platform.config.devices[sensor.deviceId] ?? {};
+  sensor.config.refreshAfter ??= (platform.config.refreshAfter ??= 3600);
+  sensor.config.enableExperimental ??= (platform.config.enableExperimental ??= false);
+  sensor.hasBattery = deviceFeatures[sensor.type].hasBattery;
+  if (sensor.hasBattery) {
+    sensor.batteryService = accessory.getService('Battery 2')
+                         || accessory.addService(platform.Service.Battery, 'Battery 2', 'battery2');
+    sensor.batteryService
+      .setCharacteristic(platform.Characteristic.Name, sensor.name)
+      .setCharacteristic(platform.Characteristic.ChargingState, platform.api.hap.Characteristic.ChargingState.NOT_CHARGEABLE)
+      .setCharacteristic(platform.Characteristic.BatteryLevel, 100);
+    sensor.batteryService
+      .getCharacteristic(platform.Characteristic.BatteryLevel).onGet(this.handleBatteryGet.bind(this, sensor));
+  }
+  // We need to serialize requests to YoLink API for each device.  Multiple threads
+  // can request state updates for a device at the same time.  This would not be good,
+  // so we need a semaphore to make sure we don't send a 2nd request to the same
+  // device before prior one has completed.
+  sensor.semaphore = new Semaphore();
+
+  this.garageService = accessory.getService(platform.Service.GarageDoorOpener)
+                    || accessory.addService(platform.Service.GarageDoorOpener);
+  this.garageService.setCharacteristic(platform.Characteristic.Name, controller.name);
+  this.garageService
+    .getCharacteristic(platform.Characteristic.CurrentDoorState)
+    .onGet(handleGet.bind(this, sensor));
+  this.garageService
+    .getCharacteristic(platform.Characteristic.TargetDoorState)
+    .onGet(handleGet.bind(this, controller))
+    .onSet(handleSet.bind(this, controller));
+  this.garageService
+    .getCharacteristic(platform.Characteristic.ObstructionDetected)
+    .onGet( () => {
+      return(false);
+    });
+
+  this.refreshDataTimer(handleGet.bind(this, controller));
+  this.refreshDataTimer(handleGet.bind(this, sensor));
+}
+
+/***********************************************************************
+ * handleGet
+ *
+ * Example for Garage Door Sensor
+ * {
+ *   "online":true,
+ *   "state":{
+ *     "alertInterval":30,
+ *     "battery":4,
+ *     "delay":10,
+ *     "openRemindDelay":600,
+ *     "state":"closed",
+ *     "version":"060d",
+ *     "stateChangedAt":1661375346592
+ *   },
+ *   "deviceId":"d88b4c0200067636",
+ *   "reportAt":"2022-08-25T01:08:19.288Z"
+ * }
+ *
+ */
+async function handleGet(this: YoLinkPlatformAccessory, device): Promise<CharacteristicValue> {
+  const platform: YoLinkHomebridgePlatform = this.platform;
+  // serialize access to device data.
+  const releaseSemaphore = await device.semaphore.acquire();
+  let rc = platform.api.hap.Characteristic.CurrentDoorState.CLOSED;
+  try {
+    if (await this.checkDeviceState(platform, device)) {
+      if (device.type === 'GarageDoor' || device.type === 'Finger') {
+        this.logDeviceState(device, `Garage Door or Finger: ${(device.data.battery)?'Battery: '+device.data.battery:'No data'}`);
+        rc = (device.targetState === 'open') ? 0 : 1;
+      } else if (device.data.online && (device.data.state.state !== 'error')) {
+        // device.type must be DoorSensor
+        rc = (device.data.state.state === 'opening') ? platform.api.hap.Characteristic.CurrentDoorState.OPENING :
+          (device.data.state.state === 'open') ? platform.api.hap.Characteristic.CurrentDoorState.OPEN :
+            (device.data.state.state === 'closing') ? platform.api.hap.Characteristic.CurrentDoorState.CLOSING :
+              platform.api.hap.Characteristic.CurrentDoorState.CLOSED;
+        this.logDeviceState(device, `Garage Door Sensor: ${device.data.state.state}, Battery: ${device.data.state.battery}`);
+      } else {
+        platform.log.error(`Device offline or other error for ${device.deviceMsgName}`);
+      }
+    }
+  } catch(e) {
+    const msg = (e instanceof Error) ? e.stack : e;
+    platform.log.error('Error in GarageDoor handleGet' + platform.reportError + msg);
+  } finally {
+    await releaseSemaphore();
+  }
+  return (rc);
+}
+
+/***********************************************************************
+ * handleSet
+ *
+ * Example JSON returned...
+ *
+ * {
+ *   "code":"000000",
+ *   "time":1661293272749,
+ *   "msgid":1661293272749,
+ *   "method":"GarageDoor.toggle",
+ *   "desc":"Success",
+ *   "data":{
+ *     "stateChangedAt":1661293272748,
+ *     "loraInfo":{
+ *       "signal":-70,
+ *       "gatewayId":"abcdef1234567890",
+ *       "gateways":1
+ *     }
+ *   }
+ * }
+ *
+ * {
+ *   "code":"000000",
+ *   "time":1661360828271,
+ *   "msgid":1661360828271,
+ *   "method":"Finger.toggle",
+ *   "desc":"Success",
+ *   "data":{
+ *     "battery":4,
+ *     "version":"0803",
+ *     "time":"2022-07-24T09:06:15.000Z",
+ *     "loraInfo":{
+ *       "signal":-8,
+ *       "gatewayId":"abcdef1234567890",
+ *       "gateways":1
+ *     }
+ *   }
+ * }
+ */
+
+async function handleSet(this: YoLinkPlatformAccessory, device, value: CharacteristicValue): Promise<void> {
+  const platform: YoLinkHomebridgePlatform = this.platform;
+  const sensor = this.accessory.context.device2;
+  // serialize access to device data.
+  const releaseSemaphore = await device.semaphore.acquire();
+  try {
+    const doorState = await handleGet.bind(this)(sensor);
+    // 0=open, 1=closed, 2=opening, 3=closing, 4=stopped(not used)
+    if (value === 0 && (doorState === 0 || doorState === 2)) {
+      platform.log.warn(`Request to open garage door (${device.deviceMsgName}) ignored, door already open or opening`);
+    } else if (value === 1 && (doorState === 1 || doorState === 3)) {
+      platform.log.warn(`Request to close garage door (${device.deviceMsgName}) ignored, door already closed or closing`);
+    } else {
+      if (value === 0) {
+        sensor.data.state.state = 'opening';
+        this.garageService
+          .updateCharacteristic(platform.Characteristic.CurrentDoorState, platform.api.hap.Characteristic.CurrentDoorState.OPENING);
+      } else {
+        sensor.data.state.state = 'closing';
+        this.garageService
+          .updateCharacteristic(platform.Characteristic.CurrentDoorState, platform.api.hap.Characteristic.CurrentDoorState.CLOSING);
+      }
+      device.targetState = (value === 0) ? 'open' : 'closed';
+      await platform.yolinkAPI.setDeviceState(platform, device, undefined, 'toggle');
+    }
+  } catch(e) {
+    const msg = (e instanceof Error) ? e.stack : e;
+    platform.log.error('Error in GarageDoor handleGet' + platform.reportError + msg);
+  } finally {
+    await releaseSemaphore();
+  }
+}
+
+/***********************************************************************
+ * mqttGarageDoor
+ *
+ * {
+ *   "event":"DoorSensor.Alert",
+ *   "time":1661360844971,
+ *   "msgid":"1661360844970",
+ *   "data":{
+ *     "state":"open",
+ *     "alertType":"normal",
+ *     "battery":4,
+ *     "version":"060d",
+ *     "loraInfo":{
+ *       "signal":-24,
+ *       "gatewayId":"abcdef1234567890",
+ *       "gateways":2
+ *     },
+ *     "stateChangedAt":1661360844970
+ *   },
+ *   "deviceId":"abcdef1234567890"
+ * }
+ */
+export async function mqttGarageDoor(this: YoLinkPlatformAccessory, message): Promise<void> {
+  const platform: YoLinkHomebridgePlatform = this.platform;
+  const event = message.event.split('.');
+  // This accessory can have DoorSensor, Finger and GarageDoor(controller) devices attached
+  // but only the DoorSensor should be sending us MQTT messages.
+  if (event[0] !== 'DoorSensor') {
+    platform.log.warn(`MQTT: ${message.event} for garage door not supported. ${platform.reportError}${JSON.stringify(message)}`);
+    return;
+  }
+  // 'device2' is the sensor device...
+  const device = this.accessory.context.device2;
+  // serialize access to device data.
+  const releaseSemaphore = await device.semaphore.acquire();
+  try {
+    device.updateTime = Math.floor(new Date().getTime() / 1000) + device.config.refreshAfter;
+    const mqttMessage = `MQTT: ${message.event} for device ${device.deviceMsgName}`;
+    // Battery is checked in main MQTT handler before coming here... but only for
+    // one device attached to the accessory... it only does the "controller"
+    this.updateBatteryInfo.bind(this, device)();
+    switch (event[1]) {
+      case 'Alert':
+        // falls through
+      case 'Report':
+        // falls through
+      case 'StatusChange':
+        if (!device.data) {
+          // in rare conditions (error conditions returned from YoLink) data object will be undefined or null.
+          platform.log.warn(`Device ${device.deviceMsgName} has no data field, is device offline?`);
+          this.contactService.updateCharacteristic(platform.Characteristic.StatusFault, true);
+          break;
+        }
+        // if we received a message then device must be online
+        device.data.online = true;
+        // Merge received data into existing data object
+        if (device.data.state) {
+          Object.assign(device.data.state, message.data);
+          if (!message.data.reportAt) {
+          // mqtt data does not include a report time, so merging the objects leaves current
+          // unchanged, update the time string.
+            device.data.reportAt = this.reportAtTime.toISOString();
+          }
+        }
+        this.logDeviceState(device, `Contact: ${device.data.state.state}, Battery: ${device.data.state.battery} (MQTT: ${message.event})`);
+        this.garageService
+          .updateCharacteristic(platform.Characteristic.CurrentDoorState,
+            (message.data.state === 'open')
+              ? platform.api.hap.Characteristic.CurrentDoorState.OPEN
+              : platform.api.hap.Characteristic.CurrentDoorState.CLOSED);
+        break;
+      case 'setOpenRemind':
+        // Homebridge has no equivalent and message does not carry either contact state or battery
+        // state fields, so there is nothing we can update.
+        platform.verboseLog(mqttMessage + ' ' + JSON.stringify(message));
+        break;
+      default:
+        platform.log.warn(mqttMessage + ' not supported.' + platform.reportError + JSON.stringify(message));
+    }
+  } catch(e) {
+    const msg = (e instanceof Error) ? e.stack : e;
+    platform.log.error('Error in mqttGarageDoor' + platform.reportError + msg);
+  } finally {
+    await releaseSemaphore();
+  }
+}

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -37,7 +37,7 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
 
   // this is used to track restored cached accessories
   private readonly accessories: PlatformAccessory[] = [];
-  private readonly yolinkDevices: YoLinkPlatformAccessory[] = [];
+  private readonly deviceAccessories: YoLinkPlatformAccessory[] = [];
 
   public yolinkAPI: YoLinkAPI;
 
@@ -67,6 +67,7 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
     this.config.tokenURL ??= YOLINK_TOKEN_URL;
     this.config.refreshAfter ??= YOLINK_REFRESH_INTERVAL;
     this.config.version ??= packageJSON.version;
+    this.config.garageDoors ??= [];
 
     this.log.info(`YoLink plugin for HomeBridge version ${packageJSON.version} (c) 2022 David A. Kerr${this.reportError}`);
     this.verboseLog(`Loaded configuaration:\n${JSON.stringify(this.config)}`);
@@ -141,7 +142,7 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
     // devices retrieved from YoLink.
     for (const accessory of this.accessories) {
       const device = accessory.context.device;
-      if (!deviceList.find(x => x.deviceId === device.deviceId)) {
+      if (!deviceList.some(x => x.deviceId === device.deviceId)) {
         this.log.warn(`Removing accessory from cache: ${accessory.displayName} (${device.deviceId}), device does not exist`);
         this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       }
@@ -154,21 +155,24 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
       // something globally unique, but constant, for example, the device serial
       // number or MAC address.
       const uuid = this.api.hap.uuid.generate(device.deviceId);
-
-      if (this.config.devices[device.deviceId]) {
-        if (this.config.devices[device.deviceId].name) {
-          device.name = this.config.devices[device.deviceId].name;
-        }
-      }
-
       // see if an accessory with the same uuid has already been registered and restored from
       // the cached devices we stored in the `configureAccessory` method above.
       const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
-      const skip = (!this.config.allDevices && !this.config.devices[device.deviceId])
-             || (this.config.devices[device.deviceId] && (this.config.devices[device.deviceId].hide === true
-                                                        ||this.config.devices[device.deviceId].hide === 'true'));
-      // If "hide" is not true then we will add the accessory and the individual handler
-      // can decide what to do.
+
+      if (this.config.devices[device.deviceId]) {
+        device.name = this.config.devices[device.deviceId].name ?? device.name;
+      }
+
+      // If device is assigned to a garage door then hide it as we will
+      // handle those as special case.
+      let skip = false;
+      if (this.config.garageDoors?.some(x => (x.sensor === device.deviceId || x.controller === device.deviceId))) {
+        this.log.info(`Device ${device.name} (${device.deviceId}) assigned to a Garage Door`);
+        skip = true;
+      }
+      skip = skip || (!this.config.allDevices && !this.config.devices[device.deviceId])
+                  || (this.config.devices[device.deviceId]
+                      && (this.config.devices[device.deviceId].hide === true || this.config.devices[device.deviceId].hide === 'true'));
 
       if (skip) {
         if (existingAccessory){
@@ -176,23 +180,77 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
           this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [existingAccessory]);
         }
       } else {
-        let deviceClass;
+        let accessoryClass;
         if (existingAccessory){
           // update existing accessory
           this.verboseLog(`Restoring accessory from cache: ${existingAccessory.displayName} (${device.deviceId})`);
           existingAccessory.context.device = device;
           this.api.updatePlatformAccessories([existingAccessory]);
-          deviceClass = new YoLinkPlatformAccessory(this, existingAccessory);
+          accessoryClass = new YoLinkPlatformAccessory(this, existingAccessory);
         } else {
           // create a new accessory
           this.log.info(`Adding new accessory: ${device.name} (${device.deviceId})`);
           const accessory = new this.api.platformAccessory(device.name, uuid);
           accessory.context.device = device;
           this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
-          deviceClass = new YoLinkPlatformAccessory(this, accessory);
+          accessoryClass = new YoLinkPlatformAccessory(this, accessory);
         }
-        this.yolinkDevices.push(deviceClass);
+        this.deviceAccessories.push(accessoryClass);
       }
+    }
+
+    // Now handle garage doors... two devices bound together
+    try {
+      for (const accessory of this.accessories) {
+        const device = accessory.context.device;
+        const device2 = accessory.context.device2;
+        if (device2) {
+          if (!this.config.garageDoors?.some(x => x.controller === device.deviceId && x.sensor === device2.deviceId)) {
+            this.log.warn(`Removing Garage Door accessory from cache: ${accessory.displayName} (${device.deviceId} & ${device2.deviceId})`);
+            this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+          }
+        }
+      }
+      for (const garage of this.config.garageDoors) {
+      // check that sensor and controller are in our device list
+        const garageDevices = deviceList.filter(x => (x.deviceId === garage.controller || x.deviceId === garage.sensor));
+        if (garageDevices.length !== 2) {
+          throw new Error(`Garage Door must have two known devices.  Ignoring this door:\n${JSON.stringify(garage)}`);
+        }
+        const controller = garageDevices.find(x => x.deviceId === garage.controller);
+        const sensor = garageDevices.find(x => x.deviceId === garage.sensor);
+        if (sensor.type !== 'DoorSensor' || !(controller.type === 'Finger' || controller.type === 'GarageDoor')) {
+          throw new Error('Garage Door sensor must be of type \'DoorSensor\' and controller of type \'Finger\' or \'GarageDoor\'');
+        }
+        const uuid = this.api.hap.uuid.generate(`${garage.controller}${garage.sensor}`);
+        // see if an accessory with the same uuid has already been registered and restored from
+        // the cached devices we stored in the `configureAccessory` method above.
+        const existingAccessory = this.accessories.find(accessory => accessory.UUID === uuid);
+
+        let accessoryClass;
+        if (existingAccessory){
+          // update existing accessory
+          this.verboseLog(`Restoring accessory from cache: ${existingAccessory.displayName} ` +
+                          `(Controler: ${garage.controller}, Sensor: ${garage.sensor})`);
+          existingAccessory.context.device = controller;
+          existingAccessory.context.device2 = sensor;
+          this.api.updatePlatformAccessories([existingAccessory]);
+          accessoryClass = new YoLinkPlatformAccessory(this, existingAccessory);
+        } else {
+          // create a new accessory
+          this.log.info(`Adding new accessory: ${controller.name} ` +
+                        `(Controler: ${garage.controller}, Sensor: ${garage.sensor})`);
+          const accessory = new this.api.platformAccessory(controller.name, uuid);
+          accessory.context.device = controller;
+          accessory.context.device2 = sensor;
+          this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+          accessoryClass = new YoLinkPlatformAccessory(this, accessory);
+        }
+        this.deviceAccessories.push(accessoryClass);
+      }
+    } catch(e) {
+      const msg = String((e instanceof Error) ? e.message : e);
+      this.log.error(msg);
     }
   }
 
@@ -204,15 +262,15 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
     this.yolinkAPI.mqtt(this, (message) => {
       // This function is called for every message received over MQTT
       const data = JSON.parse(message);
-      // Find the device in the yolinkDevices list
-      const yolinkDevice = this.yolinkDevices.find(x => x.deviceId === data.deviceId);
+      // Find the device in the deviceAccessories list
+      const deviceAccessory = this.deviceAccessories.find(x => x.deviceId === data.deviceId || x.deviceId2 === data.deviceId);
       // pass the message on to the appropriate device accessory if it exists.
-      if (yolinkDevice) {
-        yolinkDevice.mqttMessage(data);
+      if (deviceAccessory) {
+        deviceAccessory.mqttMessage(data);
       } else {
         // If a device is hidden (not loaded into homebridge) then we may receive
         // messages for it... which is perfectly okay, but worth logging.
-        this.verboseLog(`mqtt received message for unknown device (${data.deviceId})`);
+        this.log.info(`MQTT received ${message.event} message for unknown device (${data.deviceId})`);
       }
     });
   }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -16,8 +16,8 @@ import { initDeviceService, mqttHandler, deviceFeatures} from './deviceHandlers'
 import { initUnknownDevice, mqttUnknownDevice } from './unknownDevice';
 
 export class YoLinkPlatformAccessory {
-  public deviceService!: Service;
-  public infoService!: Service;
+  // public deviceService!: Service;
+  // public infoService!: Service;
   /* eslint-disable @typescript-eslint/no-explicit-any */
   public config!: {
     [key: string]: any;
@@ -26,7 +26,6 @@ export class YoLinkPlatformAccessory {
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
-  public deviceSemaphore;
   public deviceId;
   public deviceMsgName;
 
@@ -37,53 +36,59 @@ export class YoLinkPlatformAccessory {
     Error.stackTraceLimit = 100;
     const device = accessory.context.device;
     this.deviceId = device.deviceId;
-    this.deviceMsgName = `${device.name} (${device.deviceId})`;
+    device.deviceMsgName = `${device.name} (${device.deviceId})`;
     this.lastReportAtTime = 0;
-    this.config = platform.config.devices[device.deviceId] ? platform.config.devices[device.deviceId] : {};
-    this.config.refreshAfter ??= (platform.config.refreshAfter ??= 3600);
-    this.config.enableExperimental ??= (platform.config.enableExperimental ??= false);
-    this.hasBattery = false;
+    device.config = platform.config.devices[device.deviceId] ?? {};
+    device.config.refreshAfter ??= (platform.config.refreshAfter ??= 3600);
+    device.config.enableExperimental ??= (platform.config.enableExperimental ??= false);
+    device.hasBattery = false;
+    // Special handling if we have two devices attached to the one accessory
+    // only known case right now is for binding a garage door sensor with controller
+    this.deviceType = (accessory.context.device2) ? 'GarageDoorCombo' : device.type;
 
     // We need to serialize requests to YoLink API for each device.  Multiple threads
     // can request state updates for a device at the same time.  This would not be good,
     // so we need a semaphore to make sure we don't send a 2nd request to the same
     // device before prior one has completed.
-    this.deviceSemaphore = new Semaphore();
+    device.semaphore = new Semaphore();
 
     // Now initialize device, creating the homebridge services as required.
     // If device type exists in our list of supported services...
-    if (initDeviceService[device.type]) {
+    if (initDeviceService[this.deviceType]) {
       // And it is not experimental, or we are allowing experimental...
-      if ((!deviceFeatures[device.type].experimental || this.config.enableExperimental)) {
+      if ((!deviceFeatures[this.deviceType].experimental || device.config.enableExperimental)) {
         // Then set accessory information...
         this.infoService = this.accessory.getService(platform.Service.AccessoryInformation) as Service;
         this.infoService
           .setCharacteristic(platform.Characteristic.Manufacturer, 'YoLink')
           .setCharacteristic(platform.Characteristic.Name, device.name)
-          .setCharacteristic(platform.Characteristic.FirmwareRevision, String(this.config.version))
-          .setCharacteristic(platform.Characteristic.Model, String((this.config.model) ? this.config.model : 'n/a'))
+          .setCharacteristic(platform.Characteristic.FirmwareRevision, String(device.config.version))
+          .setCharacteristic(platform.Characteristic.Model, String(device.config.model ?? 'n/a'))
         // YoLink does not return device serial number in the API, use deviceId instead.
           .setCharacteristic(platform.Characteristic.SerialNumber, device.deviceId);
         this.infoService
-          .getCharacteristic(platform.Characteristic.Identify).onSet(this.handleIdentifySet.bind(this));
+          .getCharacteristic(platform.Characteristic.Identify).onSet(this.handleIdentifySet.bind(this, device));
 
         // Many YoLink devices are battery powered, so makes sense to include
         // battery level service.  YoLink reports 0..4, we will convert to 0,25,50,75,100 percent
-        this.hasBattery = deviceFeatures[device.type].hasBattery;
-        if (this.hasBattery) {
-          this.batteryService = accessory.getService(platform.Service.Battery)
-                             || accessory.addService(platform.Service.Battery);
-          this.batteryService
+        // deliberately using 'device.type' here.  If 'device2' has battery handle that in the
+        // initDeviceService function.
+        device.hasBattery = deviceFeatures[device.type].hasBattery;
+        if (device.hasBattery) {
+          // We use a name here because an accessory might have two batteries (e.g. GarrageDoorCombo)
+          device.batteryService = accessory.getService('Battery')
+                               || accessory.addService(platform.Service.Battery, 'Battery', 'battery');
+          device.batteryService
             .setCharacteristic(platform.Characteristic.Name, device.name)
             .setCharacteristic(platform.Characteristic.ChargingState, platform.api.hap.Characteristic.ChargingState.NOT_CHARGEABLE)
             .setCharacteristic(platform.Characteristic.BatteryLevel, 100);
-          this.batteryService
-            .getCharacteristic(platform.Characteristic.BatteryLevel).onGet(this.handleBatteryGet.bind(this));
+          device.batteryService
+            .getCharacteristic(platform.Characteristic.BatteryLevel).onGet(this.handleBatteryGet.bind(this, device));
         }
         // And finally call the device specific initialization...
-        initDeviceService[device.type].bind(this)();
+        initDeviceService[this.deviceType].bind(this)();
       } else {
-        platform.log.warn(`Experimental device ${this.deviceMsgName} skipped. Enable experimental devices in config.`);
+        platform.log.warn(`Experimental device ${device.deviceMsgName} skipped. Enable experimental devices in config.`);
       }
     } else {
       // We do not have support for this device yet.
@@ -102,28 +107,28 @@ export class YoLinkPlatformAccessory {
    */
   async checkDeviceState(platform, device) {
     try {
-      platform.verboseLog(`checkDeviceState for ${this.deviceMsgName} (refresh after ${this.config.refreshAfter} seconds)`);
+      platform.verboseLog(`checkDeviceState for ${device.deviceMsgName} (refresh after ${device.config.refreshAfter} seconds)`);
       const timestamp = Math.floor(new Date().getTime() / 1000);
       if (!device.data
-        || (this.config.refreshAfter === 0)
-        || ((this.config.refreshAfter > 0) && (timestamp >= device.updateTime))) {
+        || (device.config.refreshAfter === 0)
+        || ((device.config.refreshAfter > 0) && (timestamp >= device.updateTime))) {
         // If we have never retrieved data from the device, or data is older
         // than period we want to allow, then retireve new data from the device.
         // Else return with data unchanged.
         device.budp = await platform.yolinkAPI.getDeviceState(platform, device);
         if (device.budp) {
           device.data = device.budp.data;
-          device.updateTime = timestamp + this.config.refreshAfter;
+          device.updateTime = timestamp + device.config.refreshAfter;
           // reportAtTime is the earlier of the time stamp on this message, or
           // or the time reported in the message from YoLink. We use this to
           // only log (in like mode), when we have an update.
           const msgTime = new Date(parseInt(device.budp.msgid));
           const repTime = new Date(device.data?.reportAt ?? '9999-12-31');
           this.reportAtTime = (msgTime < repTime) ? msgTime : repTime;
-          this.updateBatteryInfo.bind(this)();
+          this.updateBatteryInfo.bind(this, device)();
         } else {
           device.data = undefined;
-          platform.log.error(`checkDeviceState received no data for ${this.deviceMsgName}`);
+          platform.log.error(`checkDeviceState received no data for ${device.deviceMsgName}`);
         }
       }
     } catch(e) {
@@ -137,15 +142,15 @@ export class YoLinkPlatformAccessory {
    * logDeviceState
    *
    */
-  logDeviceState(this: YoLinkPlatformAccessory, msg: string) {
+  logDeviceState(this: YoLinkPlatformAccessory, device, msg: string) {
     // reportAtTime is the earlier of the time stamp on this message, or
     // or the time reported in the message from YoLink. We use this to
     // only log (in like mode), when we have an update.
     if (this.lastReportAtTime < this.reportAtTime.getTime()) {
       this.lastReportAtTime = this.reportAtTime.getTime();
-      this.platform.log.info(`At ${this.reportAtTime.toLocaleString()}: Device state for ${this.deviceMsgName} is: ${msg}`);
+      this.platform.log.info(`At ${this.reportAtTime.toLocaleString()}: Device state for ${device.deviceMsgName} is: ${msg}`);
     } else {
-      this.platform.liteLog(`At ${this.reportAtTime.toLocaleString()}: Device state for ${this.deviceMsgName} is: ${msg}`);
+      this.platform.liteLog(`At ${this.reportAtTime.toLocaleString()}: Device state for ${device.deviceMsgName} is: ${msg}`);
     }
   }
 
@@ -161,16 +166,16 @@ export class YoLinkPlatformAccessory {
     const platform: YoLinkHomebridgePlatform = this.platform;
     const device = this.accessory.context.device;
 
-    platform.verboseLog(`Data refresh timer for ${this.deviceMsgName} fired`);
+    platform.verboseLog(`Data refresh timer for ${device.deviceMsgName} fired`);
 
     await handleGet.bind(this)();
 
-    if (this.config.refreshAfter >= 60) {
+    if (device.config.refreshAfter >= 60) {
       // We don't allow for regular updates any more frequently than once a minute. And the
       // timer will wait for at least one second before firing again to avoid runaway loops.
       const nextUpdateIn = (device.updateTime) ? Math.max(1, device.updateTime - Math.floor(new Date().getTime() / 1000)) : 60;
       // If there was no device.updateTime then error occurred, so default to 60 seconds.
-      platform.verboseLog(`Set data refresh timer for ${this.deviceMsgName} to run in ${nextUpdateIn} seconds`);
+      platform.verboseLog(`Set data refresh timer for ${device.deviceMsgName} to run in ${nextUpdateIn} seconds`);
       setTimeout( () => {
         this.refreshDataTimer(handleGet);
       }, nextUpdateIn * 1000);
@@ -181,22 +186,22 @@ export class YoLinkPlatformAccessory {
    * updateBatteryInfo
    *
    */
-  updateBatteryInfo(this: YoLinkPlatformAccessory) {
+  updateBatteryInfo(this: YoLinkPlatformAccessory, device) {
     const platform: YoLinkHomebridgePlatform = this.platform;
     let batteryLevel = 100;
 
     try {
-      if (this.hasBattery) {
+      if (device.hasBattery) {
         // Some devices wrap battery information under a 'state' object.
         // If nothing defined then assume 100%
-        batteryLevel = ((this.accessory.context.device.data.battery ?? this.accessory.context.device.data.state.battery) ?? 4) * 25;
-        const msg = `Battery level for ${this.deviceMsgName} is: ${batteryLevel-25}..${batteryLevel}%`;
+        batteryLevel = ((device.data.battery ?? device.data.state.battery) ?? 4) * 25;
+        const msg = `Battery level for ${device.deviceMsgName} is: ${batteryLevel}%`;
         if (batteryLevel <= 25) {
-          this.batteryService.updateCharacteristic(platform.Characteristic.StatusLowBattery,
+          device.batteryService.updateCharacteristic(platform.Characteristic.StatusLowBattery,
             platform.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_LOW);
           this.platform.log.warn(msg);
         } else {
-          this.batteryService.updateCharacteristic(platform.Characteristic.StatusLowBattery,
+          device.batteryService.updateCharacteristic(platform.Characteristic.StatusLowBattery,
             platform.api.hap.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL);
           this.platform.verboseLog(msg);
         }
@@ -212,15 +217,15 @@ export class YoLinkPlatformAccessory {
    * handleBatteryGet
    *
    */
-  async handleBatteryGet(this: YoLinkPlatformAccessory): Promise<CharacteristicValue> {
-    const device = this.accessory.context.device;
+  async handleBatteryGet(this: YoLinkPlatformAccessory, device): Promise<CharacteristicValue> {
+    // const device = this.accessory.context.device;
     const platform = this.platform;
     // serialize access to device data.
-    const releaseSemaphore = await this.deviceSemaphore.acquire();
+    const releaseSemaphore = await device.semaphore.acquire();
     let rc = 100;
     try {
       if (await this.checkDeviceState(platform, device)) {
-        rc = this.updateBatteryInfo.bind(this)();
+        rc = this.updateBatteryInfo.bind(this, device)();
       }
     } catch(e) {
       const msg = (e instanceof Error) ? e.stack : e;
@@ -235,12 +240,12 @@ export class YoLinkPlatformAccessory {
    *
    */
 
-  async handleIdentifySet(this: YoLinkPlatformAccessory, value): Promise<void> {
+  async handleIdentifySet(this: YoLinkPlatformAccessory, device, value): Promise<void> {
     const platform = this.platform;
     // serialize access to device data.
-    const releaseSemaphore = await this.deviceSemaphore.acquire();
+    const releaseSemaphore = await device.semaphore.acquire();
     try {
-      platform.log.info(`YoLink Device: ${this.deviceMsgName} identify '${value}' (unsupported)`);
+      platform.log.info(`YoLink Device: ${device.deviceMsgName} identify '${value}' (unsupported)`);
     } catch(e) {
       const msg = (e instanceof Error) ? e.stack : e;
       platform.log.error('Error in handleIdentitySet' + platform.reportError + msg);
@@ -264,14 +269,14 @@ export class YoLinkPlatformAccessory {
         const msgTime = new Date(parseInt(message.msgid));
         const repTime = new Date(message.data?.reportAt ?? '9999-12-31');
         this.reportAtTime = (msgTime < repTime) ? msgTime : repTime;
-        this.updateBatteryInfo.bind(this)();
-        if (mqttHandler[device.type]) {
-          mqttHandler[device.type].bind(this)(message);
+        this.updateBatteryInfo.bind(this, device)();
+        if (mqttHandler[this.deviceType]) {
+          mqttHandler[this.deviceType].bind(this)(message);
         } else {
           mqttUnknownDevice.bind(this)(message);
         }
       } else {
-        platform.log.warn(`MQTT: ${message.event} for uninitialized device ${this.deviceMsgName}`
+        platform.log.warn(`MQTT: ${message.event} for uninitialized device ${device.deviceMsgName}`
                            + platform.reportError + JSON.stringify(message));
       }
     } catch(e) {

--- a/src/unknownDevice.ts
+++ b/src/unknownDevice.ts
@@ -20,7 +20,7 @@ export async function initUnknownDevice(this: YoLinkPlatformAccessory): Promise<
   const platform: YoLinkHomebridgePlatform = this.platform;
   const device = this.accessory.context.device;
 
-  platform.log.warn(`YoLink device type: '${device.type}' is not supported (${this.deviceMsgName}) (initialize)`
+  platform.log.warn(`YoLink device type: '${device.type}' is not supported (${device.deviceMsgName}) (initialize)`
     + platform.reportError + JSON.stringify(device));
 
   this.refreshDataTimer(handleGet.bind(this));
@@ -32,17 +32,17 @@ export async function initUnknownDevice(this: YoLinkPlatformAccessory): Promise<
  */
 async function handleGet(this: YoLinkPlatformAccessory): Promise<CharacteristicValue> {
   const platform: YoLinkHomebridgePlatform = this.platform;
+  const device = this.accessory.context.device;
   // serialize access to device data.
-  const releaseSemaphore = await this.deviceSemaphore.acquire();
+  const releaseSemaphore = await device.semaphore.acquire();
   try {
-    const device = this.accessory.context.device;
     if( await this.checkDeviceState(platform, device) ) {
 
-      platform.log.warn(`YoLink device type: '${device.type}' is not supported (${this.deviceMsgName}) (handleGet)`
+      platform.log.warn(`YoLink device type: '${device.type}' is not supported (${device.deviceMsgName}) (handleGet)`
         + platform.reportError + JSON.stringify(device.data));
 
     } else {
-      platform.log.error(`Device offline or other error for ${this.deviceMsgName}`);
+      platform.log.error(`Device offline or other error for ${device.deviceMsgName}`);
     }
   } catch(e) {
     const msg = (e instanceof Error) ? e.stack : e;
@@ -59,12 +59,12 @@ async function handleGet(this: YoLinkPlatformAccessory): Promise<CharacteristicV
  */
 export async function mqttUnknownDevice(this: YoLinkPlatformAccessory, message): Promise<void> {
   const platform: YoLinkHomebridgePlatform = this.platform;
+  const device = this.accessory.context.device;
   // serialize access to device data.
-  const releaseSemaphore = await this.deviceSemaphore.acquire();
+  const releaseSemaphore = await device.semaphore.acquire();
   try {
-    const device = this.accessory.context.device;
 
-    platform.log.warn(`YoLink device type: '${device.type}' is not supported (${this.deviceMsgName}) (MQTT)`
+    platform.log.warn(`YoLink device type: '${device.type}' is not supported (${device.deviceMsgName}) (MQTT)`
       + platform.reportError + JSON.stringify(message));
 
   } catch(e) {

--- a/src/yolinkAPI.ts
+++ b/src/yolinkAPI.ts
@@ -421,19 +421,19 @@ export class YoLinkAPI {
     });
 
     this.mqttClient.on('close', () => {
-      platform.log.info(`MQTT close: Connected: ${this.mqttClient.connected}`);
+      platform.verboseLog(`MQTT close: Connected: ${this.mqttClient.connected}`);
     });
 
     this.mqttClient.on('disconnect', (packet) => {
-      platform.log.info('MQTT disconnect:' + packet);
+      platform.verboseLog('MQTT disconnect:' + packet);
     });
 
     this.mqttClient.on('offline', () => {
-      platform.log.info(`MQTT offline: Connected: ${this.mqttClient.connected}`);
+      platform.verboseLog(`MQTT offline: Connected: ${this.mqttClient.connected}`);
     });
 
     this.mqttClient.on('end', () => {
-      platform.log.info('MQTT end');
+      platform.verboseLog('MQTT end');
     });
 
     this.mqttClient.on('error', (error) => {


### PR DESCRIPTION
This merges major code changes.  To support Garage Door accessory type it is necessary to attach two YoLink devices to the one accessory (a Door Sensor and a controller).  This required code changes so that device-specific elements are attached to the "device" and not to the "accessory", hence fairly broad changes.

The MQTT reconnect code is also updated to make it more stable when network connection drops and later comes up, allowing for change of IP address and expiration of credentials. 