### PR TITLE
Fix multi-instance accessory removal race condition

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -331,6 +331,7 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
       this.log.info(`[${device.deviceMsgName}] Restoring accessory from cache`);
       existingAccessory.context.device = device;
       existingAccessory.context.device2 = device2;
+      existingAccessory.context.platformName = this.config.name;
       this.api.updatePlatformAccessories([existingAccessory]);
       this.deviceAccessories.push(new YoLinkPlatformAccessory(this, existingAccessory));
       return (existingAccessory);
@@ -340,6 +341,7 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
       const accessory = new this.api.platformAccessory(device.name, uuid);
       accessory.context.device = device;
       accessory.context.device2 = device2;
+      accessory.context.platformName = this.config.name;
       this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
       this.deviceAccessories.push(new YoLinkPlatformAccessory(this, accessory));
       return (accessory);
@@ -356,6 +358,18 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
       const accessory = this.accessories[i];
       const device: YoLinkDevice = accessory.context.device;
       if (!deviceList.some(x => x.deviceId === device.deviceId)) {
+        // Multi-instance guard: skip accessories that belong to a different platform instance.
+        // If platformName is unset (pre-fix accessory), also skip to be conservative —
+        // it will get tagged on its next restore cycle.
+        const ownerName: string | undefined = accessory.context.platformName;
+        if (ownerName !== undefined && ownerName !== this.config.name) {
+          this.verboseLog(`Skipping removal of accessory ${accessory.displayName} (${device.deviceId}) — belongs to platform "${ownerName}"`);
+          continue;
+        }
+        if (ownerName === undefined) {
+          this.verboseLog(`Skipping removal of accessory ${accessory.displayName} (${device.deviceId}) — no platformName set (pre-fix accessory)`);
+          continue;
+        }
         this.log.warn(`Removing accessory from cache: ${accessory.displayName} (${device.deviceId}), device does not exist`);
         const indexKnownDevices = this.knownDevices.indexOf(device.deviceId);
         if (indexKnownDevices >= 0) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -49,6 +49,11 @@ export type YoLinkDevice = {
   [key: string]: any;
 };
 
+// Module-level shared cache so all instances can access cached accessories.
+// Homebridge delivers ALL cached accessories for this plugin to only ONE instance,
+// so other instances need a way to find their own accessories.
+const sharedAccessoryCache: Map<string, PlatformAccessory> = new Map();
+
 export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service;
   public readonly Characteristic: typeof Characteristic;
@@ -146,6 +151,9 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
    */
   configureAccessory(accessory: PlatformAccessory) {
     this.verboseLog('Loading accessory from cache:' + accessory.displayName);
+    // Store in shared cache so other instances can find their accessories.
+    // Homebridge only delivers cached accessories to one instance of this plugin.
+    sharedAccessoryCache.set(accessory.UUID, accessory);
     // add the restored accessory to the accessories cache so we can track if it has already been registered
     this.accessories.push(accessory);
   }
@@ -205,6 +213,16 @@ export class YoLinkHomebridgePlatform implements DynamicPlatformPlugin {
    * registerDevices
    */
   async registerDevices() {
+    // Multi-instance support: Homebridge delivers all cached accessories for this
+    // plugin to only one instance. Check the shared cache for accessories that belong
+    // to us but were delivered to another instance.
+    for (const [uuid, accessory] of sharedAccessoryCache) {
+      if (accessory.context?.platformName === this.config.name &&
+          !this.accessories.some(a => a.UUID === uuid)) {
+        this.log.info(`Claiming accessory from shared cache: ${accessory.displayName} (${accessory.context?.device?.deviceId || '?'})`);
+        this.accessories.push(accessory);
+      }
+    }
     const deviceList: YoLinkDevice[] = await this.yolinkAPI.getDeviceList(this);
     this.removeDeletedDevices(deviceList);
 


### PR DESCRIPTION
## Summary

Fixes a bug where running multiple homebridge-yolink instances (e.g. two YoLink accounts) causes one instance's accessories to be re-created as new on every restart, wiping Home app room assignments, automations, and custom names.

Fixes #133

## Root Cause

Two issues combine to cause this bug:

1. **Homebridge delivers all cached accessories for a plugin to only one instance.** When two homebridge-yolink platform entries exist, only one instance receives `configureAccessory()` calls for all cached yolink accessories. The other instance's `this.accessories` array is always empty.

2. **`removeDeletedDevices()` removes accessories from other instances.** The instance that receives all cached accessories sees the other instance's devices, can't find them in its own YoLink account, and unregisters them.

## Fix (3 changes to `src/platform.ts`)

1. **Module-level `sharedAccessoryCache` Map** — When `configureAccessory()` is called, accessories are stored in a shared Map that all instances can access.

2. **`registerDevices()`** — Before processing devices, each instance checks the shared cache for accessories tagged with its `config.name` and adds them to its own `this.accessories` array.

3. **`removeDeletedDevices()`** — Before removing a cached accessory, check `accessory.context.platformName`. Skip if it belongs to another instance or is untagged (pre-fix, conservative).

4. **`addDevice()`** — Tags every accessory with `context.platformName = this.config.name` for ownership tracking.

## Test plan

- [x] Run two homebridge-yolink instances with different YoLink accounts
- [x] Restart Homebridge — verify both instances log "Restoring accessory from cache" (not "Adding new accessory")
- [x] Restart again — confirm stable behavior, no "Removing" or "Adding new" messages
- [x] Verify cache file has no duplicate entries after multiple restarts
- [ ] Verify single-instance setups are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)