### PR TITLE
Handle THSensor.DataRecord MQTT events (fixes #62)

### DIFF
--- a/src/thermoHydroDevice.ts
+++ b/src/thermoHydroDevice.ts
@@ -197,7 +197,11 @@ async function handleGetBlocking(this: YoLinkPlatformAccessory, sensor = 'thermo
  *    "deviceId": "abcdef1234567890"
  *  }
  *
- * The newer X3 sensor also sends a DataRecord which we will quietly ignore
+ * The newer X3 family of sensors (e.g. YS8004, YS8006, YS8008) push DataRecord
+ * events. Each DataRecord carries an array of one or more historical samples,
+ * oldest first. For these devices DataRecord is frequently the only push the
+ * plugin receives, so we extract the newest sample and treat it as the current
+ * state. See https://github.com/dkerr64/homebridge-yolink/issues/62
  * {
  *   "event": "THSensor.DataRecord",
  *   "time": 1665651601414,
@@ -309,8 +313,36 @@ export async function mqttThermoHydroDevice(this: YoLinkPlatformAccessory, messa
           platform.log.warn(`Device ${device.deviceMsgName} reports low battery`);
         }
         break;
-      case 'DataRecord':
-      // falls through
+      case 'DataRecord': {
+        // X3 family THSensors (e.g. YS8004, YS8006, YS8008) often push DataRecord
+        // rather than Report; without handling this the value in HomeKit stays
+        // stuck on the last Report (or last refresh poll) until the next refresh.
+        // Each DataRecord carries an array of samples; we take the newest.
+        // See https://github.com/dkerr64/homebridge-yolink/issues/62
+        if (!device.data) {
+          platform.log.warn(`Device ${device.deviceMsgName} has no data field, is device offline?`);
+          break;
+        }
+        const records = message.data?.records;
+        if (!Array.isArray(records) || records.length === 0) {
+          platform.liteLog(mqttMessage + ' (no records in payload) ' + JSON.stringify(message, null, 2));
+          break;
+        }
+        const latest = records.reduce((a, b) =>
+          new Date(b.time).getTime() > new Date(a.time).getTime() ? b : a);
+        device.data.online = true;
+        device.data.state.temperature = latest.temperature;
+        device.data.state.humidity = latest.humidity;
+        device.data.reportAt = latest.time ?? device.reportAtTime.toISOString();
+        this.logDeviceState(device, `Temperature ${latest.temperature}°C ` +
+          `(${(latest.temperature * 9 / 5 + 32).toFixed(1)}°F), ` +
+          `Humidity ${latest.humidity}${batteryMsg} (MQTT: ${message.event})`);
+        this.thermoService?.updateCharacteristic(
+          platform.Characteristic.CurrentTemperature, latest.temperature);
+        this.hydroService?.updateCharacteristic(
+          platform.Characteristic.CurrentRelativeHumidity, latest.humidity);
+        break;
+      }
       case 'setAlarm':
         // No equivalent for this in HomeKit
         platform.liteLog(mqttMessage + ' ' + JSON.stringify(message, null, 2));


### PR DESCRIPTION
## Problem

X3-family YoLink temperature/humidity sensors (YS8004, YS8006, YS8008, ...) push their state via `THSensor.DataRecord` MQTT events rather than (or in addition to) `THSensor.Report`. The existing handler in `thermoHydroDevice.ts` dumps these to `liteLog` and discards them, so the temperature visible in HomeKit can be stuck on a very old value (until the next `refreshAfter` cloud poll fires, which is up to 4 hours by default).

Reported in #62 (open since 2022-10-13). Same root cause likely behind #121.

## What the payload looks like

DataRecord carries an array of historical samples, oldest first. A real capture from my YS8008-UC pool thermometer:

```json
{
  "event": "THSensor.DataRecord",
  "data": {
    "records": [
      { "temperature": 21.3, "humidity": 0, "time": "2026-05-19T14:16:40.000Z" },
      { "temperature": 21.4, "humidity": 0, "time": "2026-05-19T14:26:40.000Z" },
      { "temperature": 21.6, "humidity": 0, "time": "2026-05-19T14:36:40.000Z" }
    ]
  },
  "deviceId": "d88b4c0200138916"
}
```

The newest sample is the current state. Notably it preserves one-decimal precision (e.g. `21.6` instead of the integer `20` that `THSensor.getState` was returning for the same device at roughly the same time, hours apart from a fresh Report).

## What this PR does

In `thermoHydroDevice.ts`:

1. Replaces the `case 'DataRecord':` no-op with a handler that picks the newest sample from `message.data.records` (by `time`) and writes it into `device.data.state`.
2. Logs the update via `logDeviceState(...)` in the same format as `Report`, tagged `(MQTT: THSensor.DataRecord)` so it's clear in logs which path produced the update.
3. Pushes the new value to `CurrentTemperature` / `CurrentRelativeHumidity` via the existing characteristics.
4. Defensive: if `records` is missing or empty, falls back to the prior liteLog behavior; if `device.data` is null (offline), logs the same warning as `Report`.
5. Updates the file header comment that previously documented DataRecord as 'quietly ignored'.

The handler does not fall through to `Report` because `Report` reads `message.data.alarm.lowBattery`, which DataRecord doesn't carry. Duplicating the few lines of update logic kept the control flow obvious.

`setAlarm` remains a no-op as before.

## Verification

Patched plugin running on my Homebridge instance against a real YS8008-UC. The next live DataRecord push processed correctly:

```
[19/05/2026, 11:46:39] [YoLink] [YS8008-UC (...) Pool Thermometer]
  At 19/05/2026, 11:46:39: Device state updated:
  Temperature 22.3°C (72.1°F), Humidity 0 (MQTT: THSensor.DataRecord) [lite]
```

Before the patch the same device was stuck at 20°C / 68.0°F (the cloud REST API's last cached integer reading from a refresh poll many minutes earlier).

`npm run lint` and `npm run build` both clean.

## Notes for review

- I don't think DataRecord ever carries an `alarm` field, so `message.data.alarm.lowBattery` is intentionally not checked here. If a future YoLink firmware adds it, the existing `Report` handler still runs on its own DataRecord-adjacent messages.
- The `(no records in payload)` branch shouldn't fire for current firmware (every sample I've captured has at least one record), but it preserves the previous liteLog behavior as a safety net.
- The maintainer noted in #62 that they don't have an X3 device to test with. I'm running this live on a YS8008-UC, happy to gather additional captures or test specific scenarios.

Fixes #62.