### PR TITLE
Fix SprinklerV2 (YS4103) showing Idle in HomeKit while watering

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,14 @@ This plugin expects to receive status updates from YoLink devices when status ch
 
 A Leak Sensor and, if supported, a Temperature Sensor service is added with this device. The name of each has "Leak" and "Temperature" appended to the end. *YS-5006-UC* is known not to report temperature.
 
+### Sprinkler
+
+YoLink sprinkler devices register as irrigation valves in HomeKit. The *YS4103* single-zone timer registers as a HomeKit valve, and the *YS4102* multi-zone controller registers as a HomeKit irrigation system with one valve per zone. As with the water meter controller above, HomeKit separates open/close (the *Active* characteristic) from in-use (the *InUse* characteristic). In-use drives the "Running" or "Idle" label and is meant to indicate that water is actually flowing.
+
+The *YS4103* timer reports a *waterFlowing* value from its flow meter, but, like the water valve, it does not update this in real time. It is only refreshed when the plugin polls the device. Basing in-use on *waterFlowing* would leave Apple Home showing "Idle" while the sprinkler is actually running. Therefore, by default, this plugin reports in-use based on whether the sprinkler is running. You can set the config *useWaterFlowing* setting to use the flow meter status from the device instead. If you do, consider lowering *refreshAfter* for this device only (minimum 60 seconds, not recommended globally) so the flow value updates more frequently.
+
+The *YS4102* multi-zone controller is implemented from the YoLink API documentation only and has not been verified against live hardware. It does not report a flow meter, so in-use always follows whether a zone is watering and the *useWaterFlowing* setting has no effect.
+
 ### Unsupported Devices
 
 If you have a device not supported by the plugin then useful information will be logged as warnings, including callback messages received for any alerts or status changes triggered by the device. Please capture these logs and report to the author by opening a [issue](https://github.com/dkerr64/homebridge-yolink/issues).

--- a/config.schema.json
+++ b/config.schema.json
@@ -243,7 +243,7 @@
       "useWaterFlowing": {
         "title": "Use waterFlowing status from YoLink water valves",
         "type": "boolean",
-        "description": "YoLink water meter controller valves can report whether water is flowing. This sets whether to use this when informing HomeKit that a valve is InUse. Default is to assume InUse if valve is open."
+        "description": "YoLink water meter controller valves and the YS4103 sprinkler timer can report whether water is flowing. This sets whether to use this when informing HomeKit that the device is InUse. Default is to assume InUse if the valve is open or the sprinkler is running."
       },
       "leakAsContact": {
         "title": "Use HomeKit contact instead of leak sensor",
@@ -376,7 +376,7 @@
                 "useWaterFlowing": {
                   "title": "Use waterFlowing status from YoLink water valves",
                   "type": "boolean",
-                  "description": "YoLink water meter controller valves can report whether water is flowing. This sets whether to use this when informing HomeKit that a valve is InUse. Default is to assume InUse if valve is open."
+                  "description": "YoLink water meter controller valves and the YS4103 sprinkler timer can report whether water is flowing. This sets whether to use this when informing HomeKit that the device is InUse. Default is to assume InUse if the valve is open or the sprinkler is running."
                 },
                 "leakAsContact": {
                   "title": "Use HomeKit contact instead of leak sensor",

--- a/src/sprinklerV2.ts
+++ b/src/sprinklerV2.ts
@@ -28,6 +28,12 @@ export async function initSprinklerV2Device(this: YoLinkPlatformAccessory): Prom
   // timer to regularly update the data.
   await this.refreshDataTimer(handleGetBlocking.bind(this, 'valve'));
 
+  // Check config for whether we should use the waterFlowing value for the InUse
+  // characteristic, and that the device actually returns a waterFlowing state.
+  this.useWaterFlowing = (device.config.useWaterFlowing ?? false)
+    && Object.prototype.hasOwnProperty.call(device.data ?? {}, 'waterFlowing');
+  platform.verboseLog(`Device ${device.deviceMsgName} InUse set based on waterFlowing state: ${this.useWaterFlowing}`);
+
   // Once we have initial data, setup all the Homebridge handlers
   this.valveService.getCharacteristic(platform.Characteristic.Active)
     .onGet(handleGet.bind(this, 'valve'))
@@ -91,8 +97,14 @@ function computeCachedValue(this: YoLinkPlatformAccessory, devSensor: string): C
   const platform: YoLinkHomebridgePlatform = this.platform;
   const device: YoLinkDevice = this.accessory.context.device;
   const running = device.data?.state?.running === true;
-  const waterFlowing = (typeof device.data?.waterFlowing === 'number')
-    ? device.data.waterFlowing > 0
+  // HomeKit InUse drives the "Running" vs "Idle" label. By default mirror the
+  // valve running state. The YS4103 flow meter (waterFlowing) only updates on
+  // an explicit getState (poll), not in the real-time MQTT stream, so basing
+  // InUse on it would leave HomeKit stuck at "Idle" while watering. Set config
+  // useWaterFlowing to true to drive InUse from the flow meter instead. This
+  // mirrors the WaterMeterController handling in valveDevice.ts.
+  const waterFlowing = (this.useWaterFlowing)
+    ? (Number(device.data?.waterFlowing) > 0)
     : running;
   switch (devSensor) {
     case 'valve':


### PR DESCRIPTION
## Problem

On the YS4103-UC battery sprinkler timer, HomeKit shows the valve turned **On** while watering, but the status label stays **Idle** instead of **Running** (with the remaining-time countdown).

## Root cause

In `computeCachedValue` (src/sprinklerV2.ts), the HomeKit `InUse` characteristic (which drives the Running vs Idle label) was computed only from the flow-meter field `waterFlowing`. The fallback to the valve `running` state never executed, because the YS4103 always reports `waterFlowing` as a number (`0` when no flow has been measured).

The key behaviour: the YS4103 only returns a live `waterFlowing` value in an explicit `getState` response (a manual refresh / poll), not in the real-time MQTT stream. When watering starts, the MQTT message sets `state.running = true` (so `Active` flips to ON) but carries `waterFlowing: 0`, leaving `InUse` at `NOT_IN_USE`, so HomeKit shows Idle. The plugin's periodic poll does not rescue this either, since each incoming MQTT message pushes `device.updateTime` forward by `refreshAfter`, suppressing a fresh `getState` for the duration of the watering session. This was confirmed against live hardware: the YoLink app itself only shows a flow rate after a manual refresh.

## Fix

Drive `InUse` from the reliable `running` state, still honoring a positive flow reading when one is present:

```js
const waterFlowing = running || (Number(device.data?.waterFlowing) > 0);
```

All paths that update `InUse` (poll/on-demand get, set, and the MQTT handler) route through `computeCachedValue('flowing')`, so this single change fixes them all. `Active`, `RemainingDuration`, and `SetDuration` are unchanged. The multi-zone `Sprinkler` (YS4102) handler already derives in-use from `watering.left > 0` and is not affected.

Follow-up to #138. `npm run build` and `npm run lint` both pass.