### PR TITLE
Reject DataRecord pushes whose samples all have epoch-0 timestamps

### DIFF
--- a/src/thermoHydroDevice.ts
+++ b/src/thermoHydroDevice.ts
@@ -328,7 +328,24 @@ export async function mqttThermoHydroDevice(this: YoLinkPlatformAccessory, messa
           platform.liteLog(mqttMessage + ' (no records in payload) ' + JSON.stringify(message, null, 2));
           break;
         }
-        const latest = records.reduce((a, b) =>
+        // Some X3 sensors intermittently push a DataRecord whose samples are all
+        // zero and stamped with an epoch-0 timestamp (1970-01-01T00:00:00.000Z).
+        // Applying those would pin CurrentTemperature to 0°C until the next good
+        // report. Drop samples with a missing/invalid/epoch-0 timestamp, and if
+        // none remain, ignore the event and hold the last good value. We key off
+        // the bad timestamp rather than a zero temperature because 0°C is a
+        // legitimate reading for the freezer/outdoor sensors served by this same
+        // code path.
+        const valid = records.filter((r) => {
+          const t = new Date(r.time).getTime();
+          return Number.isFinite(t) && t > 0;
+        });
+        if (valid.length === 0) {
+          platform.log.warn(`${device.deviceMsgName} DataRecord rejected: all ${records.length} ` +
+            'sample(s) have epoch-0/invalid timestamps, holding last value ' + JSON.stringify(message.data));
+          break;
+        }
+        const latest = valid.reduce((a, b) =>
           new Date(b.time).getTime() > new Date(a.time).getTime() ? b : a);
         device.data.online = true;
         device.data.state.temperature = latest.temperature;


### PR DESCRIPTION
### Problem

Follow-up to #144 (DataRecord handling for the X3-family THSensors). One of my YS8008 pool sensors intermittently pushes a `THSensor.DataRecord` whose samples are **all zero and stamped with an epoch-0 timestamp**. Captured live from the MQTT stream:

```json
{"event":"THSensor.DataRecord","time":1782688269329,
 "data":{"records":[
   {"temperature":0,"humidity":0,"time":"1970-01-01T00:00:00.000Z"},
   {"temperature":0,"humidity":0,"time":"1970-01-01T00:00:00.000Z"}
   /* ...10 identical samples... */ ]},
 "deviceId":"d88b4c0200138916"}
```

The newest-by-time reducer picks one of these and applies `temperature: 0`, so HomeKit's `CurrentTemperature` gets pinned to **0 °C / 32 °F** until the next good report (often many minutes later). The YoLink app is unaffected because it follows the real reports, so the device looks fine there while HomeKit reads freezing.

### Fix

Before selecting the newest sample, drop any record whose timestamp is missing / unparseable / epoch-0; if none remain, ignore the event and keep the last good value (logging a warning).

The guard keys off the **bad timestamp, not a zero temperature** — `0 °C` is a legitimate reading for the freezer and outdoor sensors handled by this same code path, so filtering on temperature would suppress real data.

### Testing

- `npm run lint` (`--max-warnings=0`) and `npm run build` pass.
- Verified the logic against three inputs: the captured all-zero/epoch-0 payload (rejected, value held), a normal multi-sample record (newest picked), and a legitimate single `0 °C`-with-real-timestamp record (kept).
- Running the built change on my own Homebridge instance: the pool sensor holds its real value across the glitch and logs the rejection when the bad payload arrives.
